### PR TITLE
Added new Makefile tasks: aws-setup/teardown = to populate / remove s…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,22 @@ shell:
 clean:
 	rm -rf .bundle/
 	rm -rf vendor/
+	
+aws-setup:
+	aws --endpoint-url='http://localhost:4566' s3 mb 's3://ruby-etl-lambda-inbox' 
+	aws --endpoint-url='http://localhost:4566' s3 mb 's3://ruby-etl-lambda-outbox'
+	aws --endpoint-url='http://localhost:4566' s3 cp 'test/resources/ABC_Collection-June-2020_03.xlsm' 's3://ruby-etl-lambda-inbox/ABC_Collection-June-2020_03.xlsm'
+
+aws-teardown:
+	aws --endpoint-url='http://localhost:4566' s3 rb 's3://ruby-etl-lambda-inbox' --force
+	aws --endpoint-url='http://localhost:4566' s3 rb 's3://ruby-etl-lambda-outbox' --force
+	
+docker-up:
+	docker-compose up -d
+	
+docker-down:
+	docker-compose down
+
+lambda-test:
+	curl -XPOST "http://localhost:8080/2015-03-31/functions/function/invocations" -d '{"input_bucket":"ruby-etl-lambda-inbox","output_bucket":"ruby-etl-lambda-outbox","object_key":"ABC_Collection-June-2020_03.xlsm","mappings": File.open('test/resources/national_collection.yml', 'r').read}'
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.7'
+services:
+    localstack:
+        image: localstack/localstack:0.11.2
+        environment:
+            - DATA_DIR=/tmp/localstack/data
+            - DEFAULT_REGION=eu-west-2
+            - DOCKER_HOST=unix:///var/run/docker.sock
+            - PORT_WEB_UI=8090
+            - SERVICES=s3,dynamodb,ssm,sqs
+#            - DEBUG=1 # Uncomment to enable debug logging in localstack
+        restart: always
+        ports:
+            - "4566:4566"  # Entrypoint Service
+            - "4572:4572"  # S3 direct access port left open as hadoop fails when pointing to 4566
+            - "4576:4576"  # SQS direct access port left open for lambda testing
+        command: start
+        volumes:
+          - /tmp/localstack:/tmp/localstack
+          - /var/run/docker.sock:/var/run/docker.sock
+    lambda:
+        image: lambda-ruby2.7
+        ports:
+            - "8080:8080"
+        depends_on:
+            - localstack
+        volumes:
+          - .:/var/task


### PR DESCRIPTION
Created a docker-compose file to create a network with the containerised lambda and localstack for local testing.

Added new Makefile tasks:

- aws-setup/teardown = to populate / remove s3 resources
- docker-up/down = to start/stop docker-compose stack 
- lambda-test = to trigger lambda function respectively

I've attached a copy of the error I obtained when triggering the lambda in this way - think it might be due to a missing dependency in the container?
[lambda-error.txt](https://github.com/timgentry/ndr_parquet-lambda/files/6495405/lambda-error.txt)
